### PR TITLE
release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.2.1](https://github.com/MikeDev75015/mongodb-pipeline-builder/compare/v3.2.0...v3.2.1) (2021-07-14)
+
+
+### Bug Fixes
+
+* correct the interpretation of 0 as not valid when passed as an argument of the GetDocs method ([f32531d](https://github.com/MikeDev75015/mongodb-pipeline-builder/commit/f32531de6404a46270d766c2d09c927f8ffab6d5))
+
 ## [3.2.0](https://github.com/MikeDev75015/mongodb-pipeline-builder/compare/v3.1.2...v3.2.0) (2021-07-11)
 
 

--- a/lib/methods/get-result/get-result.ts
+++ b/lib/methods/get-result/get-result.ts
@@ -57,7 +57,7 @@ export const GetResult = async (
     // Default result
     return {
       GetDocs: (element?: number | 'last') => {
-        if (!element) {
+        if (element === undefined) {
           return result;
         }
         const lastIndex = result.length - 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-pipeline-builder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-pipeline-builder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Pipeline constructor for the aggregate method of a mongoDB collection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- fix: correct the interpretation of 0 as not valid when passed as an argument of the GetDocs method
- chore(release): 3.2.1
